### PR TITLE
solve ij -> i bottleneck in sparse version

### DIFF
--- a/tests/test_equivariance.py
+++ b/tests/test_equivariance.py
@@ -59,7 +59,7 @@ def test_egnn_sparse_equivariance():
     feats2, coors2 = out2[:, 3:], out2[:, :3]
 
     print(feats1 - feats2)
-    print(apply_action(coors1), coors2)
+    print(apply_action(coors1) - coors2)
     assert torch.allclose(feats1, feats2), 'features must be invariant'
     assert torch.allclose(apply_action(coors1), coors2), 'coordinates must be equivariant'
 


### PR DESCRIPTION
I don't recommend normalizing the weights nor the coords. 
* The weights are the coefficient that multiplies the delta in the i->j direction
* the coords are the deltas in the i->j direction
Can't see the advantage of normalizing them beyond a naive stabilization that might affect the convergence properties by needing more layers due to the limited transformation that a layer will be able to do. 

It works fine for denoising without normalization (the unstability might come from huge outliers, but then tuning the learning rate or clipping the gradients might be of help.)