### PR TITLE
Fix errors thrown if no pygm due to undefined types

### DIFF
--- a/egnn_pytorch/egnn_pytorch.py
+++ b/egnn_pytorch/egnn_pytorch.py
@@ -18,6 +18,12 @@ try:
 except:
     MessagePassing = object
     PYG_AVAILABLE = False
+    
+    # to stop throwing errors from type suggestions
+    Adj = object
+    Size = object
+    OptTensor = object
+    Tensor = object
 
 # helper functions
 


### PR DESCRIPTION
Fix references to undefined objects if pytorch geometric is not installed